### PR TITLE
#4 resetting summary

### DIFF
--- a/faraobot.rb
+++ b/faraobot.rb
@@ -20,6 +20,9 @@ end
 #ドロップ倍率
 DROPRATIO = setting_farao['dropRatio']
 
+#メッセージ通知チャンネル
+CHANNELID = setting_auth['bot']['channel_id']
+
 #ドロップアイテムの絵文字コード
 EMOJDROP1 = setting_farao['drop1']['emoji']
 EMOJDROP2 = setting_farao['drop2']['emoji']

--- a/settings/auth.json.example
+++ b/settings/auth.json.example
@@ -1,6 +1,7 @@
 {
 	"bot": {
 		"token": "your_bot_token",
-		"client_id": 1234567890
+		"client_id": 1234567890,
+		"channel_id": 1234567890
 	}
 }


### PR DESCRIPTION
fix #4 

- 通知channnel用idを追加
-  `bot.run` を非同期にする
- メインスレッドのloopで日付変更をチェック
  - 日付が変わったらsummaryをリセット
  - summary時の日付を追加で記録する
  - 日付変更前に当日のsummaryを通知
